### PR TITLE
Translatable catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Tenant/segment dependency to use the right locale headers for calling vtex.catalog-graphql when necessary
 
 ## [0.1.14] - 2019-10-24
 

--- a/manifest.json
+++ b/manifest.json
@@ -20,8 +20,15 @@
     {
       "name": "outbound-access",
       "attrs": {
-        "host": "httpstat.us",
-        "path": "*"
+        "host": "portal.vtexcommercestable.com.br",
+        "path": "/api/segments/*"
+      }
+    },
+    {
+      "name": "outbound-access",
+      "attrs": {
+        "host": "portal.vtexcommercestable.com.br",
+        "path": "/api/tenant/tenants"
       }
     },
     {
@@ -32,9 +39,6 @@
     },
     {
       "name": "vbase-read-write"
-    },
-    {
-      "name": "vtex.catalog-api-proxy:catalog-proxy"
     },
     {
       "name": "vtex.catalog-graphql:resolve-graphql"

--- a/node/index.ts
+++ b/node/index.ts
@@ -1,6 +1,7 @@
 import { LRUCache, method, Service } from '@vtex/api'
 
 import { Clients } from './clients'
+import { locale } from './middlewares/locale'
 import { notify } from './middlewares/notify'
 import { parseAndValidate } from './middlewares/parse'
 import { settings } from './middlewares/settings'
@@ -44,7 +45,7 @@ export default new Service<Clients, State>({
   },
   routes: {
     notify: method({
-      POST: [settings, parseAndValidate, notify],
+      POST: [locale, settings, parseAndValidate, notify],
     }),
   },
 })

--- a/node/middlewares/locale.ts
+++ b/node/middlewares/locale.ts
@@ -1,0 +1,34 @@
+const TEN_MINUTES_S = 10 * 60
+
+const getTenant = async (clients: Context['clients']) => {
+  const { segment: segmentClient, tenant } = clients
+  const [ segmentData, tenantInfo ] = await Promise.all([
+    segmentClient.getSegmentByToken(null),
+    tenant.info({
+      forceMaxAge: TEN_MINUTES_S,
+      nullIfNotFound: true,
+    }).catch(_ => null),
+  ])
+  const cultureFromTenant = tenantInfo && tenantInfo.defaultLocale
+  const cultureFromDefaultSegment = segmentData && segmentData.cultureInfo
+
+  return {
+    locale: cultureFromTenant || cultureFromDefaultSegment,
+  }
+}
+
+export async function locale(ctx: Context, next: () => Promise<any>) {
+
+  /** 
+   * Insert tenant and locale values into the context so we call
+   * all other services with the correct headers
+  */
+  if (!ctx.vtex.tenant || !ctx.vtex.locale) {
+    const tenantInfo = await getTenant(ctx.clients) 
+    
+    ctx.vtex.tenant = tenantInfo
+    ctx.vtex.locale = tenantInfo.locale
+  }
+  
+  await next()
+}

--- a/node/middlewares/notify.ts
+++ b/node/middlewares/notify.ts
@@ -1,5 +1,5 @@
 import { IOContext } from '@vtex/api'
-import { isEmpty } from 'ramda'
+import { isEmpty, isNil } from 'ramda'
 
 import { Clients } from '../clients'
 import { USER_BUCKET } from '../constants'
@@ -12,7 +12,19 @@ import {
   toProductProvider,
   toSkuProvider,
 } from '../utils/catalog'
-import { brandChanged, categoryChanged, productChanged, skuChanged } from './../utils/event'
+import {
+  brandChanged,
+  categoryChanged,
+  productChanged,
+  skuChanged,
+} from './../utils/event'
+
+const isStorage = (maybeStorage: {} | Storage | null): maybeStorage is Storage => {
+  if (isNil(maybeStorage) || isEmpty(maybeStorage)) {
+    return false
+  }
+  return true
+}
 
 const replaceIfChanged = async <T>(
   data: T,
@@ -23,7 +35,7 @@ const replaceIfChanged = async <T>(
 
   const oldHash = await vbase
     .getJSON<Storage | null>(USER_BUCKET, fileName, true)
-    .then(maybeHash => maybeHash && maybeHash.hash)
+    .then(maybeHash => isStorage(maybeHash) ? maybeHash.hash : null)
     
   if (oldHash !== hash) {
     await vbase.saveJSON<Storage>(USER_BUCKET, fileName, { hash })

--- a/node/package.json
+++ b/node/package.json
@@ -7,7 +7,7 @@
     "@types/co-body": "^0.0.3",
     "@types/node": "12.x",
     "@types/ramda": "types/npm-ramda#dist",
-    "@vtex/api": "^3.48.2",
+    "@vtex/api": "^3.62.4",
     "eslint": "^6.3.0",
     "eslint-config-vtex": "^11.0.0",
     "prettier": "^1.18.2",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -281,13 +281,15 @@
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-"@vtex/api@^3.48.2":
-  version "3.48.2"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-3.48.2.tgz#d61af504f7afc64cadd9756052b5677488f85492"
-  integrity sha512-h14zSyhZ6xO8mwtJ3mcJD1S1quIS7ahcnJL6U/pRRBRDtNFBAn9rm297pFxhzypgqFgVcuB5ZN4eiK/b7vUcfQ==
+"@vtex/api@^3.62.4":
+  version "3.62.4"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-3.62.4.tgz#705030a3f72086bd8ff7f715634d4e46d9924b0f"
+  integrity sha512-HRmoxuDxS+9eT1KawVwoeRQrMQwzSudX6NOHAfljRYCB3qzolPSJ4Ls62uXEq0ny7+HP7dm6ayrkHnGZ3alVCA==
   dependencies:
     "@types/koa" "^2.0.48"
     "@types/koa-compose" "^3.2.3"
+    "@wry/equality" "^0.1.9"
+    agentkeepalive "^4.0.2"
     apollo-datasource "^0.3.1"
     apollo-server-core "^2.4.8"
     apollo-server-errors "^2.2.1"
@@ -304,6 +306,7 @@
     graphql-extensions "^0.5.7"
     graphql-tools "^3.1.1"
     graphql-upload "^8.0.4"
+    js-base64 "^2.5.1"
     koa-compose "^4.1.0"
     lru-cache "^5.1.1"
     mime-types "^2.1.12"
@@ -315,6 +318,14 @@
     semver "^5.5.1"
     stats-lite vtex/node-stats-lite#dist
     tar-fs "^2.0.0"
+    xss "^1.0.6"
+
+"@wry/equality@^0.1.9":
+  version "0.1.9"
+  resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.1.9.tgz#b13e18b7a8053c6858aa6c85b54911fb31e3a909"
+  integrity sha512-mB6ceGjpMGz1ZTza8HYnrPGos2mC6So4NhS1PtZ8s4Qt0K7fBiIGhpSxUbQmhwcSWE3no+bYxmI2OL6KuXYmoQ==
+  dependencies:
+    tslib "^1.9.3"
 
 acorn-jsx@^5.0.2:
   version "5.0.2"
@@ -325,6 +336,15 @@ acorn@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.0.0.tgz#26b8d1cd9a9b700350b71c0905546f64d1284e7a"
   integrity sha512-PaF/MduxijYYt7unVGRuds1vBC9bFxbNf+VWqhOClfdgy7RlVkQqt610ig1/yxTgsDIfW1cWDel5EBbOy3jdtQ==
+
+agentkeepalive@^4.0.2:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-4.1.0.tgz#a48e040ed16745dd29ce923675f60c9c90f39ee0"
+  integrity sha512-CW/n1wxF8RpEuuiq6Vbn9S8m0VSYDMnZESqaJ6F2cWN9fY8rei2qaxweIaRgq+ek8TqfoFIsUjaGNKGGEHElSg==
+  dependencies:
+    debug "^4.1.0"
+    depd "^1.1.2"
+    humanize-ms "^1.2.1"
 
 ajv@^6.10.0, ajv@^6.10.2:
   version "6.10.2"
@@ -700,6 +720,11 @@ color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
 
+commander@^2.9.0:
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+
 compress-commons@^1.2.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/compress-commons/-/compress-commons-1.2.2.tgz#524a9f10903f3a813389b0225d27c48bb751890f"
@@ -751,6 +776,11 @@ cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
+cssfilter@0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/cssfilter/-/cssfilter-0.0.10.tgz#c6d2672632a2e5c83e013e6864a42ce8defd20ae"
+  integrity sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4=
+
 dataloader@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-1.4.0.tgz#bca11d867f5d3f1b9ed9f737bd15970c65dff5c8"
@@ -762,7 +792,7 @@ debug@=3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@^4.0.1:
+debug@^4.0.1, debug@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
@@ -780,7 +810,7 @@ define-properties@^1.1.2:
   dependencies:
     object-keys "^1.0.12"
 
-depd@~1.1.2:
+depd@^1.1.2, depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
 
@@ -1218,6 +1248,13 @@ http-errors@^1.7.1:
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
 
+humanize-ms@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/humanize-ms/-/humanize-ms-1.2.1.tgz#c46e3159a293f6b896da29316d8b6fe8bb79bbed"
+  integrity sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=
+  dependencies:
+    ms "^2.0.0"
+
 iconv-lite@0.4.23:
   version "0.4.23"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
@@ -1354,6 +1391,11 @@ iterall@^1.1.3, iterall@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.2.2.tgz#92d70deb8028e0c39ff3164fdbf4d8b088130cd7"
   integrity sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA==
+
+js-base64@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.5.1.tgz#1efa39ef2c5f7980bb1784ade4a8af2de3291121"
+  integrity sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw==
 
 js-tokens@^4.0.0:
   version "4.0.0"
@@ -1500,7 +1542,7 @@ ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
-ms@^2.1.1:
+ms@^2.0.0, ms@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
@@ -1847,7 +1889,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:
@@ -2124,6 +2166,14 @@ ws@^6.0.0:
   integrity sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==
   dependencies:
     async-limiter "~1.0.0"
+
+xss@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/xss/-/xss-1.0.6.tgz#eaf11e9fc476e3ae289944a1009efddd8a124b51"
+  integrity sha512-6Q9TPBeNyoTRxgZFk5Ggaepk/4vUOYdOsIUYvLehcsIZTFjaavbVnsuAkLA5lIFuug5hw8zxcB9tm01gsjph2A==
+  dependencies:
+    commander "^2.9.0"
+    cssfilter "0.0.10"
 
 xtend@^4.0.0:
   version "4.0.1"


### PR DESCRIPTION
`vtex.catalog-graphql` uses new headers for allowing translations. This PR makes that broadcaster call tenant/segment services for retrieving the necessary info for filling the right headers before calling `vtex.catalog-graphql`