### PR TITLE
Adds cache to tenant and segment clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- LRU Cache to tenant/segment clients
 
 ## [0.2.0] - 2019-11-11
 ### Added

--- a/node/index.ts
+++ b/node/index.ts
@@ -9,15 +9,15 @@ import { settings } from './middlewares/settings'
 const ONE_SECOND_MS = 1000
 const TREE_SECONDS_MS = 3 * 1000
 
-const vbaseCacheStorage = new LRUCache<string, any>({
+const vbaseCacheStorage = new LRUCache<string, Cached>({
   max: 5000,
 })
 
-const appsCacheStorage = new LRUCache<string, any>({
+const appsCacheStorage = new LRUCache<string, Cached>({
   max: 2500,
 })
 
-const catalogCacheStorage = new LRUCache<string, any>({
+const catalogCacheStorage = new LRUCache<string, Cached>({
   max: 5000,
 })
 

--- a/node/index.ts
+++ b/node/index.ts
@@ -25,10 +25,15 @@ const tenantCacheStorage = new LRUCache<string, Cached>({
   max: 3000
 })
 
+const segmentCacheStorage = new LRUCache<string, Cached>({
+  max: 3000
+})
+
 metrics.trackCache('vbase', vbaseCacheStorage)
 metrics.trackCache('apps', appsCacheStorage)
 metrics.trackCache('catalog', catalogCacheStorage)
 metrics.trackCache('tenant', tenantCacheStorage)
+metrics.trackCache('segment', segmentCacheStorage)
 
 export default new Service<Clients, State>({
   clients: {
@@ -52,7 +57,7 @@ export default new Service<Clients, State>({
         timeout: TREE_SECONDS_MS
       },
       segment: {
-        memoryCache: tenantCacheStorage,
+        memoryCache: segmentCacheStorage,
         timeout: TREE_SECONDS_MS
       }
     },

--- a/node/middlewares/locale.ts
+++ b/node/middlewares/locale.ts
@@ -1,9 +1,9 @@
 const TEN_MINUTES_S = 10 * 60
 
 const getTenant = async (clients: Context['clients']) => {
-  const { segment: segmentClient, tenant } = clients
+  const { segment, tenant } = clients
   const [ segmentData, tenantInfo ] = await Promise.all([
-    segmentClient.getSegmentByToken(null),
+    segment.getSegmentByToken(null),
     tenant.info({
       forceMaxAge: TEN_MINUTES_S,
       nullIfNotFound: true,


### PR DESCRIPTION
In the last PR I've forgotten to add LRU caches to segment and tenant clients. This PR adds those caches and track them