### PR TITLE
Disables broadcasting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Disable broadcasting of events
 
 ## [0.6.0] - 2020-03-06
 ### Fixed

--- a/node/middlewares/settings.ts
+++ b/node/middlewares/settings.ts
@@ -24,7 +24,7 @@ export async function settings(ctx: Context, next: () => Promise<any>) {
   // of this pipeline. For enabling only 50% of the requests
   // to go forward, you can replace the following line with
   // the code: `const enabledGlobally = Math.random() < 0.5`
-  const enabledGlobally = true
+  const enabledGlobally = false
 
   const { enabled: enabledInWorkspace, alwaysNotify } = enabledGlobally 
     ? await apps.getAppSettings(VTEX_APP_AT_MAJOR).then(parseSettings)


### PR DESCRIPTION
Since this broadcaster does not receives all changes from the catalog, it is causing some bugs in the routing system. Therefore I think we should disable this while the channels team does not deploy the changes in SC Broadcaster